### PR TITLE
Run openCV operations in a python subprocess

### DIFF
--- a/.find_boxes.py
+++ b/.find_boxes.py
@@ -2,6 +2,7 @@ import sys
 import cv2
 import numpy as np
 import json
+import base64
 
 
 class Point:
@@ -31,7 +32,7 @@ class RectEncoder(json.JSONEncoder):
 
 def find_boxes(threshold, box_size_lower, box_size_upper, img):
     # find boxes by first applying a threshold filter to the grayscale window
-    gray = cv2.cvtColor(np.array(img, dtype=np.uint8), cv2.COLOR_BGR2GRAY)
+    gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
     # gray = cv2.cvtColor(np.array(img), cv2.COLOR_BGR2GRAY)
     _, thresh = cv2.threshold(gray, threshold, 255, cv2.THRESH_BINARY)
     # view_image(thresh, "thresh")
@@ -83,8 +84,12 @@ def find_boxes(threshold, box_size_lower, box_size_upper, img):
 
 if __name__ == "__main__":
     args = json.load(sys.stdin)
-    # print(args["threshold"])
 
-    find_boxes(
-        args["threshold"], args["box_size_lower"], args["box_size_upper"], args["img"]
-    )
+    # convert base64 string to numpy array
+    img_b64 = base64.b64decode(args["img"])
+    img = np.frombuffer(img_b64, dtype=np.uint8)
+
+    # reshape array to image dimensions
+    img = img.reshape(args["height"], args["width"], 3)
+
+    find_boxes(args["threshold"], args["box_size_lower"], args["box_size_upper"], img)

--- a/.find_boxes.py
+++ b/.find_boxes.py
@@ -1,0 +1,90 @@
+import sys
+import cv2
+import numpy as np
+import json
+
+
+class Point:
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+
+class Rect:
+    def __init__(self, x, y, w, h):
+        self.x = x
+        self.y = y
+        self.w = w
+        self.h = h
+        self.center = Point(x + w / 2, y + h / 2)
+
+
+class RectEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, Rect):
+            out_dict = obj.__dict__
+            del out_dict["center"]
+            return out_dict
+
+        return json.JSONEncoder.default(self, obj)
+
+
+def find_boxes(threshold, box_size_lower, box_size_upper, img):
+    # find boxes by first applying a threshold filter to the grayscale window
+    gray = cv2.cvtColor(np.array(img, dtype=np.uint8), cv2.COLOR_BGR2GRAY)
+    # gray = cv2.cvtColor(np.array(img), cv2.COLOR_BGR2GRAY)
+    _, thresh = cv2.threshold(gray, threshold, 255, cv2.THRESH_BINARY)
+    # view_image(thresh, "thresh")
+
+    # use a close morphology transform to filter out thin lines
+    kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (2, 1))
+    morph = cv2.morphologyEx(thresh, cv2.MORPH_CLOSE, kernel)
+    # view_image(morph, "morph")
+
+    # now search all of the contours for small square-ish things
+    contours, _ = cv2.findContours(morph, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
+
+    all_boxes = []
+    for c in contours:
+        (x, y, w, h) = cv2.boundingRect(c)
+        if (
+            (w >= box_size_lower and w < box_size_upper)
+            and (h > box_size_lower and h < box_size_upper)
+            and abs(w - h) < 0.4 * w
+        ):
+            all_boxes.append(Rect(x, y, w, h))
+
+    # print("found boxes", len(all_boxes))
+
+    # filter boxes that are too similar to each other
+    boxes = []
+    for i, box1 in enumerate(all_boxes):
+        omit = False
+        for j in range(i + 1, len(all_boxes)):
+            box2 = all_boxes[j]
+            box1center = box1.center
+            box2center = box2.center
+            if (
+                abs(box1center.x - box2center.x) < box_size_lower
+                and abs(box1center.y - box2center.y) < box_size_lower
+            ):
+                # omit this box since its center is nearby another box's center
+                omit = True
+                break
+
+        if not omit:
+            boxes.append(box1)
+
+    # print("after omissions", len(boxes))
+
+    # print boxes as json
+    print(json.dumps(boxes, cls=RectEncoder, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    args = json.load(sys.stdin)
+    # print(args["threshold"])
+
+    find_boxes(
+        args["threshold"], args["box_size_lower"], args["box_size_upper"], args["img"]
+    )

--- a/flex_mouse_grid.py
+++ b/flex_mouse_grid.py
@@ -974,43 +974,24 @@ class FlexMouseGrid:
         self.boxes_showing = b
         self.grid_showing = g
 
-    def setup_boxes(self):
+    def find_boxes(self, scan=False):
         self.reset_window_context()
 
         # temporarily hide everything that we have drawn so that it doesn't interfere with box detection
         self.temporarily_hide_everything()
 
-        # use box lower and upper bounds from settings
+        # use a threshold of -1 to indicate that we should scan for a good threshold
+        threshold = -1 if scan else self.box_config["threshold"]
+
+        # retrieve the app-specific box detection configuration
         box_size_lower = self.box_config["box_size_lower"]
         box_size_upper = self.box_config["box_size_upper"]
-
-        # use a threshold of -1 to indicate that we should scan for a good threshold
-        threshold = -1
 
         # perform box detection
         self.find_boxes_with_config(threshold, box_size_lower, box_size_upper)
 
         # save final threshold
         self.save_box_config()
-
-        # restore everything previously hidden and show boxes
-        self.restore_everything()
-        self.boxes_showing = True
-        self.redraw()
-
-    def find_boxes(self):
-        self.reset_window_context()
-
-        # temporarily hide everything that we have drawn so that it doesn't interfere with box detection
-        self.temporarily_hide_everything()
-
-        # retrieve the app-specific box detection configuration
-        threshold = self.box_config["threshold"]
-        box_size_lower = self.box_config["box_size_lower"]
-        box_size_upper = self.box_config["box_size_upper"]
-
-        # perform box detection
-        self.find_boxes_with_config(threshold, box_size_lower, box_size_upper)
 
         # restore everything previously hidden and show boxes
         self.restore_everything()
@@ -1259,7 +1240,7 @@ class GridActions:
 
     def flex_grid_setup_boxes():
         """Do a binary search to find best box configuration"""
-        mg.setup_boxes()
+        mg.find_boxes(scan=True)
 
     def flex_grid_go_to_box(box_number: int, mouse_button: int):
         """Go to a box"""

--- a/flex_mouse_grid.py
+++ b/flex_mouse_grid.py
@@ -20,8 +20,7 @@ from talon.types.point import Point2d
 import typing
 import string
 import time
-
-# import cv2
+import cv2
 import numpy as np
 import subprocess
 
@@ -1016,7 +1015,7 @@ class FlexMouseGrid:
         box_size_upper = self.box_config["box_size_upper"]
 
         def find_boxes_with_threshold(threshold):
-            # self.find_boxes_with_config(threshold, box_size_lower, box_size_upper)
+            self.find_boxes_with_config(threshold, box_size_lower, box_size_upper)
             return len(self.boxes)
 
         # first do a broad scan, checking number of boxes found across a range of thresholds
@@ -1063,62 +1062,62 @@ class FlexMouseGrid:
         box_size_upper = self.box_config["box_size_upper"]
 
         # perform box detection
-        # self.find_boxes_with_config(threshold, box_size_lower, box_size_upper)
+        self.find_boxes_with_config(threshold, box_size_lower, box_size_upper)
 
         # restore everything previously hidden and show boxes
         self.restore_everything()
         self.boxes_showing = True
         self.redraw()
 
-    # def find_boxes_with_config(self, threshold, box_size_lower, box_size_upper):
-    #     # find boxes by first applying a threshold filter to the grayscale window
-    #     img = np.array(screen.capture_rect(self.rect))
-    #     gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
-    #     _, thresh = cv2.threshold(gray, threshold, 255, cv2.THRESH_BINARY)
-    #     # view_image(thresh, "thresh")
+    def find_boxes_with_config(self, threshold, box_size_lower, box_size_upper):
+        # find boxes by first applying a threshold filter to the grayscale window
+        img = np.array(screen.capture_rect(self.rect))
+        gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+        _, thresh = cv2.threshold(gray, threshold, 255, cv2.THRESH_BINARY)
+        # view_image(thresh, "thresh")
 
-    #     # use a close morphology transform to filter out thin lines
-    #     kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (2, 1))
-    #     self.morph = cv2.morphologyEx(thresh, cv2.MORPH_CLOSE, kernel)
-    #     # view_image(morph, "morph")
+        # use a close morphology transform to filter out thin lines
+        kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (2, 1))
+        self.morph = cv2.morphologyEx(thresh, cv2.MORPH_CLOSE, kernel)
+        # view_image(morph, "morph")
 
-    #     # now search all of the contours for small square-ish things
-    #     contours, _ = cv2.findContours(
-    #         self.morph, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE
-    #     )
+        # now search all of the contours for small square-ish things
+        contours, _ = cv2.findContours(
+            self.morph, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE
+        )
 
-    #     all_boxes = []
-    #     for c in contours:
-    #         (x, y, w, h) = cv2.boundingRect(c)
-    #         if (
-    #             (w >= box_size_lower and w < box_size_upper)
-    #             and (h > box_size_lower and h < box_size_upper)
-    #             and abs(w - h) < 0.4 * w
-    #         ):
-    #             all_boxes.append(ui.Rect(x, y, w, h))
+        all_boxes = []
+        for c in contours:
+            (x, y, w, h) = cv2.boundingRect(c)
+            if (
+                (w >= box_size_lower and w < box_size_upper)
+                and (h > box_size_lower and h < box_size_upper)
+                and abs(w - h) < 0.4 * w
+            ):
+                all_boxes.append(ui.Rect(x, y, w, h))
 
-    #     # print("found boxes", len(all_boxes))
+        # print("found boxes", len(all_boxes))
 
-    #     # filter boxes that are too similar to each other
-    #     self.boxes = []
-    #     for i, box1 in enumerate(all_boxes):
-    #         omit = False
-    #         for j in range(i + 1, len(all_boxes)):
-    #             box2 = all_boxes[j]
-    #             box1center = box1.center
-    #             box2center = box2.center
-    #             if (
-    #                 abs(box1center.x - box2center.x) < box_size_lower
-    #                 and abs(box1center.y - box2center.y) < box_size_lower
-    #             ):
-    #                 # omit this box since its center is nearby another box's center
-    #                 omit = True
-    #                 break
+        # filter boxes that are too similar to each other
+        self.boxes = []
+        for i, box1 in enumerate(all_boxes):
+            omit = False
+            for j in range(i + 1, len(all_boxes)):
+                box2 = all_boxes[j]
+                box1center = box1.center
+                box2center = box2.center
+                if (
+                    abs(box1center.x - box2center.x) < box_size_lower
+                    and abs(box1center.y - box2center.y) < box_size_lower
+                ):
+                    # omit this box since its center is nearby another box's center
+                    omit = True
+                    break
 
-    #         if not omit:
-    #             self.boxes.append(box1)
+            if not omit:
+                self.boxes.append(box1)
 
-    #     # print("after omissions", len(self.boxes))
+        # print("after omissions", len(self.boxes))
 
     def go_to_box(self, box_number):
         if box_number >= len(self.boxes):


### PR DESCRIPTION
With Talon v0.4.0, we are no longer able to directly import cv2 (openCV) into the Talon python environment. As a workaround, spawn a new subprocess that performs the necessary openCV operations. Namely, finding boxes given image data.

This is essentially a bug fix and shouldn't change any functionality.