### PR TITLE
Edited the readme to also have a windows installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ notable differences from Dense Mouse Grid:
 ~/.talon/bin/pip install opencv-python-headless
 ~/.talon/bin/pip install numpy
 ```
+On Windows, in a Powershell run the following commands:
+```
+cd (New-Object -ComObject WScript.Shell).CreateShortcut("$env:USERPROFILE/AppData/Roaming/talon/bin.lnk").TargetPath
+./pip.bat install opencv-python-headless
+./pip.bat install numpy
+```
+(on Windows the bin folder is a shortcut file that cannot be as simply navigated to)
 
 4. Clone this repository into your Talon user directory (on MacOS,
    `~/.talon/user`).

--- a/README.md
+++ b/README.md
@@ -29,22 +29,25 @@ notable differences from Dense Mouse Grid:
    along with the community repository, but is compatible with any repository
    that provides the letters a-z using the `<user.letters>` capture and numbers
    using the `<numbers>` capture.
-3. Install the python dependencies. Assuming the default install location on a
-   Mac, run these commands:
+3. Install the python dependencies with the below instructions.
+
+- On Mac, run these commands in a terminal:
 
 ```
 ~/.talon/bin/pip install opencv-python-headless
 ~/.talon/bin/pip install numpy
 ```
-On Windows, in a Powershell run the following commands:
+
+- On Windows, run the following commands in a Powershell. Note: on Windows the
+  bin folder is a shortcut file that cannot be simply navigated to.
+
 ```
 cd (New-Object -ComObject WScript.Shell).CreateShortcut("$env:USERPROFILE/AppData/Roaming/talon/bin.lnk").TargetPath
 ./pip.bat install opencv-python-headless
 ./pip.bat install numpy
 ```
-(on Windows the bin folder is a shortcut file that cannot be as simply navigated to)
 
-4. Clone this repository into your Talon user directory (on MacOS,
+4. Clone this repository into your Talon user directory (on MacOS, located at
    `~/.talon/user`).
 5. Restart Talon, can't hurt.
 6. Try the voice command `flex grid`!


### PR DESCRIPTION
Added a few lines read me to give some commands to install on windows. It is not quite as clean as the mac/Linux command, but should have the same effect.

I didn't change this but I don't think that the numpy installation is required? As it is included by default in talon (at least I already had it installed unless I had installed it for a different reason), and is a dependency in the opencv library so should be installed anyway.

Hope all looks good